### PR TITLE
Add TYPE field required by ABRT

### DIFF
--- a/lib/abrt/handler.rb
+++ b/lib/abrt/handler.rb
@@ -24,6 +24,7 @@ private
     io.write "PID=#{Process.pid}\0"
     io.write "EXECUTABLE=#{exception.executable}\0"
     io.write "ANALYZER=Ruby\0"
+    io.write "TYPE=Ruby\0"
     io.write "BASENAME=rbhook\0"
     io.write "REASON=#{exception.format.first}\0"
     io.write "BACKTRACE=#{exception.format.join("\n")}\0"


### PR DESCRIPTION
ABRT has recently started to refuse all incoming problems without TYPE
field. The field is basically equal to ANALYZER field which is
deprecated an should be completely removed in the future.

It is not safe to remove ANALYZER field yet.

Signed-off-by: Jakub Filak jfilak@redhat.com
