### PR TITLE
Replace syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ gem "abrt", :require => false
 
 line into your *Gemfile*.
 
+### Dependencies
+
+This library is `logger` utility from util-linux for logging purposes. Please
+make sure it is available on your system for proper functionality.
+
 ## Usage
 
 There are several ways how to run any application with ABRT handler enabled.

--- a/lib/abrt/handler.rb
+++ b/lib/abrt/handler.rb
@@ -1,5 +1,5 @@
 require 'socket'
-require 'syslog'
+require_relative 'util_linux_logger'
 require_relative 'exception'
 
 module ABRT
@@ -16,7 +16,7 @@ module ABRT
 private
 
   def self.syslog
-    @syslog ||= Syslog.open 'abrt'
+    @syslog ||= UtilLinuxLogger.open 'abrt'
   end
 
   def self.report(exception, io = nil)

--- a/lib/abrt/util_linux_logger.rb
+++ b/lib/abrt/util_linux_logger.rb
@@ -1,0 +1,34 @@
+# UtilLinuxLogger is small utility class intended to be drop in replacement for
+# Syslog. It uses `logger` command from util-linux project to provide system
+# logging facilities.
+#
+# It implements just minimal interface required by ABRT project.
+class UtilLinuxLogger
+  # :yields: syslog
+  #
+  # Open the UtilLinuxLoggersyslog facility.
+  #
+  # `ident` is a String which identifies the calling program.
+  def self.open(ident)
+    self.new(ident)
+  end
+
+  def initialize(ident)
+    @ident = ident
+  end
+
+  def notice(format_string, *arguments)
+    log 'user.notice', format_string, *arguments
+  end
+
+  def err(format_string, *arguments)
+    log 'user.err', format_string, *arguments
+  end
+
+private
+  def log(priority, format_string, *arguments)
+    IO.popen "logger -p #{priority} -t #{@ident} --socket-errors=off", 'w' do |io|
+      io.write sprintf(format_string, *arguments)
+    end
+  end
+end

--- a/spec/abrt_spec.rb
+++ b/spec/abrt_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper'
 describe 'ABRT' do
   context "handles exception in 'abrt.rb' with RubyGems" do
     abrt_rb = File.join(File.dirname(__FILE__), '../lib/abrt.rb')
-    output_message_pattern = /\A#{abrt_rb}:\d+:in `<main>': can't modify frozen Array(: \[1, 2, 3\])? \((FrozenError|RuntimeError)\)\n\Z/
+    output_message_pattern = /\A#{abrt_rb}:\d+:in [`']<main>': can't modify frozen Array(: \[1, 2, 3\])? \((FrozenError|RuntimeError)\)\n\Z/
 
     it 'disabled' do
       expect { system "ruby --disable-gems #{abrt_rb}" }


### PR DESCRIPTION
Use custom `UtilLinuxLogger` instead `syslog`
    
`syslog` used to be part of StdLib. But beginning with Ruby 3.4, it was extracted into default gems. This is problematic when Ruby is executed with `--disable-gems`, because there is no easy way to require `syslog`.
    
Therefore, this commit introduces custom `UtilLinuxLogger`. This use `logger` command from util-linux and implemnts just minimal `Syslog` interface required.
    
While this could have been used just as a fallback, when `syslog` can't be required, it will be easier to use it every time.

Fixes #12