### PR TITLE
Use `Tempfile` for socket tests

### DIFF
--- a/spec/abrt_handler_spec.rb
+++ b/spec/abrt_handler_spec.rb
@@ -132,13 +132,16 @@ describe "ABRT" do
 
         it "because no-one is listeing on the other side" do
           # This file is not correct UNIX socket, so it should be usable for the test.
-          socket_path = __FILE__
-          expect(abrt).to receive(:abrt_socket).and_wrap_original do |original_method, *args, &block|
-            args << __FILE__
-            original_method.call(*args)
+          require 'tempfile'
+          Tempfile.create do |tf|
+            socket_path = tf.path
+            expect(abrt).to receive(:abrt_socket).and_wrap_original do |original_method, *args, &block|
+              args << tf.path
+              original_method.call(*args)
+            end
+            expect(syslog).to receive(:err).with("%s", /can't communicate with ABRT daemon, is it running\? Connection refused -( connect\(2\) for)? "?#{socket_path}"?/)
+            abrt.handle_exception exception
           end
-          expect(syslog).to receive(:err).with("%s", /can't communicate with ABRT daemon, is it running\? Connection refused -( connect\(2\) for)? "?#{socket_path}"?/)
-          abrt.handle_exception exception
         end
       end
     end


### PR DESCRIPTION
There is a quite small limit on socket path. This leeds to test error such as the one bellow on deeply nested systems.

~~~
  1) ABRT #handle_exception logs error into syslog when can't communicate with ABRT daemon because no-one is listeing on the other side
     Failure/Error: expect(syslog).to receive(:err).with("%s", /can't communicate with ABRT daemon, is it running\? Connection refused -( connect\(2\) for)? "?#{socket_path}"?/)

       #<Double "syslog"> received :err with unexpected arguments
         expected: ("%s", /can't communicate with ABRT daemon, is it running\? Connection refused -( connect\(2\) for)? "?\/bui...ygem-abrt-0.5.0-build\/abrt-0.5.0\/usr\/share\/gems\/gems\/abrt-0.5.0\/spec\/abrt_handler_spec.rb"?/)
              got: ("%s", "can't communicate with ABRT daemon, is it running? too long unix socket path (114bytes given but 108bytes max)")
       Diff:
       @@ -1,3 +1,3 @@
        ["%s",
       - /can't communicate with ABRT daemon, is it running\? Connection refused -( connect\(2\) for)? "?\/builddir\/build\/BUILD\/rubygem-abrt-0.5.0-build\/abrt-0.5.0\/usr\/share\/gems\/gems\/abrt-0.5.0\/spec\/abrt_handler_spec.rb"?/]
       + "can't communicate with ABRT daemon, is it running? too long unix socket path (114bytes given but 108bytes max)"]
     # ./spec/abrt_handler_spec.rb:140:in 'block (5 levels) in <top (required)>'
~~~